### PR TITLE
feat: Level500- shows-first UI with search, episodes nav, and fetch caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,45 +9,51 @@
   </head>
 
   <body>
-    <div class="searchContainer" id="searchContainer">
-      <!-- Show selector (Level 400) -->
-      <label for="showSelector" class="sr-only">Select show</label>
-      <select id="showSelector">
-        <option value="">Loading shows…</option>
-      </select>
+    <!-- SHOWS VIEW (default) -->
+    <section id="showsView">
+      <div class="toolbar">
+        <label for="showSearch" class="sr-only">Search shows</label>
+        <input id="showSearch" type="search" placeholder="Search shows by name, genre, or summary..." />
+        <p>
+          Showing <span id="showCount">0</span> of <span id="showTotal">0</span> shows
+        </p>
+        <div id="loadingMessage" style="display:none">Loading…</div>
+        <div id="errorMessage" style="display:none;color:red"></div>
+      </div>
 
-      <!-- Episode selector -->
-      <label for="episodeSelector" class="sr-only">Select episode</label>
-      <select id="episodeSelector">
-        <option value="all">All Episodes</option>
-      </select>
+      <div id="showsRoot" class="shows-grid"></div>
+    </section>
 
-      <!-- Search -->
-      <label for="search" class="sr-only">Search</label>
-      <input id="search" type="search" placeholder="Search..." />
+    <!-- EPISODES VIEW -->
+    <section id="episodesView" style="display:none;">
+      <nav class="nav-back">
+        <a href="#" id="backToShows">← All shows</a>
+      </nav>
 
-      <!-- Live counts -->
-      <p title="Search For Episodes 🔎">
-        Displaying <span id="manyEpisodes">0</span> of
-        <span id="totalEpisodes">0</span> Episodes
-      </p>
+      <div class="toolbar" id="episodesToolbar">
+        <label for="episodeSelector" class="sr-only">Select episode</label>
+        <select id="episodeSelector">
+          <option value="all">All Episodes</option>
+        </select>
 
-      <!-- Status messages -->
-      <div id="loadingMessage" style="display:none">Loading…</div>
-      <div id="errorMessage" style="display:none; color:red"></div>
-    </div>
+        <label for="episodeSearch" class="sr-only">Search episodes</label>
+        <input id="episodeSearch" type="search" placeholder="Search episodes..." />
 
-    <!-- Episodes grid -->
-    <div id="root"></div>
+        <p>
+          Displaying <span id="manyEpisodes">0</span> of
+          <span id="totalEpisodes">0</span> episodes
+        </p>
+      </div>
 
-    <!-- Empty state -->
-    <div class="notAvailable" id="notAvailable" style="display:none;">
-      <h2>😕 Oops!</h2>
-      <p>We don't have this episode at the moment.</p>
-      <p>Please check back later or try searching for another one.</p>
-    </div>
+      <div id="episodesRoot" class="episode-grid"></div>
 
-    <!-- Optional intro animation (keep/remove as you like) -->
+      <div class="notAvailable" id="notAvailable" style="display:none;">
+        <h2>😕 Oops!</h2>
+        <p>No episodes match your filters.</p>
+      </div>
+    </section>
+
+    <!-- Optional intro animation -->
     <div id="intro-animation" class="intro-animation" style="display:none;">
       <div class="core"></div>
       <div class="particle p1"></div>
@@ -61,7 +67,6 @@
       <h1 class="intro-title">TVMaze STUDIOS</h1>
     </div>
 
-    <!-- App script (no episodes.js at Level 400) -->
     <script src="script.js"></script>
 
     <footer>

--- a/style.css
+++ b/style.css
@@ -1,269 +1,303 @@
+/* --------------------------
+   Base + Theme
+--------------------------- */
+:root {
+  --bg: #0f1115;
+  --panel: #161a21;
+  --text: #e7eaf0;
+  --muted: #a7b0c0;
+  --primary: #7cc0ff;
+  --accent: #8ee1b7;
+  --danger: #ff7a7a;
 
-*{
-  box-sizing: border-box;
-}
-#root {
-  padding: 20px;
-  font-family: Arial, sans-serif;
+  --radius: 14px;
+  --shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+  --ring: 0 0 0 3px rgba(124, 192, 255, 0.35);
 }
 
-.info-text {
-  font-size: 16px;
-  margin-bottom: 20px;
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f6f7fb;
+    --panel: #ffffff;
+    --text: #1b2230;
+    --muted: #5e6b82;
+    --primary: #246bff;
+    --accent: #0f9d6e;
+    --danger: #d53f3f;
+    --shadow: 0 6px 20px rgba(22, 32, 60, 0.08);
+    --ring: 0 0 0 3px rgba(36, 107, 255, 0.2);
+  }
 }
 
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  background: radial-gradient(1200px 800px at 20% -10%, rgba(124,192,255,.08), transparent 60%),
+              radial-gradient(900px 600px at 110% 20%, rgba(142,225,183,.08), transparent 60%),
+              var(--bg);
+  color: var(--text);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+img { max-width: 100%; display: block; }
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+a:hover { text-decoration: underline; }
+
+/* Accessible visually-hidden label helper */
+.sr-only {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}
+
+/* --------------------------
+   Toolbars
+--------------------------- */
+.toolbar,
+#searchContainer {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .75rem 1rem;
+  padding: .85rem 1rem;
+  background: color-mix(in oklab, var(--panel) 85%, transparent);
+  backdrop-filter: saturate(1.2) blur(8px);
+  border-bottom: 1px solid color-mix(in oklab, var(--muted) 18%, transparent);
+}
+
+.toolbar p,
+#searchContainer p {
+  margin: 0 0 0 auto;
+  font-size: .95rem;
+  color: var(--muted);
+}
+
+/* Inputs */
+input[type="search"],
+select {
+  appearance: none;
+  border: 1px solid color-mix(in oklab, var(--muted) 25%, transparent);
+  background: var(--panel);
+  color: var(--text);
+  padding: .6rem .8rem;
+  border-radius: 10px;
+  outline: none;
+  box-shadow: none;
+  transition: border-color .15s ease, box-shadow .15s ease, transform .05s ease;
+}
+
+select { padding-right: 2rem; background-image:
+  linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+  linear-gradient(135deg, var(--muted) 50%, transparent 50%),
+  linear-gradient(to right, transparent, transparent);
+background-position:
+  calc(100% - 16px) calc(50% - 3px),
+  calc(100% - 11px) calc(50% - 3px),
+  calc(100% - 2.2rem) 0.5rem;
+background-size: 5px 5px, 5px 5px, 1px 1.8rem;
+background-repeat: no-repeat;
+}
+
+input[type="search"]:focus,
+select:focus {
+  border-color: var(--primary);
+  box-shadow: var(--ring);
+}
+
+input[type="search"]:active,
+select:active { transform: translateY(0.5px); }
+
+/* Status messages */
+#loadingMessage { color: var(--muted); }
+#errorMessage { color: var(--danger) !important; }
+
+/* --------------------------
+   Layout grids
+--------------------------- */
+.shows-grid,
 .episode-grid {
+  width: min(1200px, 92vw);
+  margin: 1.2rem auto 3rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.1rem;
 }
+
+/* --------------------------
+   Show cards
+--------------------------- */
+.show-card {
+  background: var(--panel);
+  border: 1px solid color-mix(in oklab, var(--muted) 18%, transparent);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transition: transform .12s ease, box-shadow .2s ease, border-color .2s ease;
+}
+
+.show-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(0,0,0,.28);
+  border-color: color-mix(in oklab, var(--primary) 30%, transparent);
+}
+
+.show-card h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  padding: .85rem 1rem;
+  border-bottom: 1px solid color-mix(in oklab, var(--muted) 14%, transparent);
+}
+
+.show-card h2 a { text-decoration: none; }
+.show-card h2 a:hover { text-decoration: underline; }
+
+.show-meta {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.show-meta img {
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid color-mix(in oklab, var(--muted) 18%, transparent);
+}
+
+.show-info { display: grid; gap: .5rem; }
+
+.show-summary {
+  margin: 0;
+  color: var(--text);
+  opacity: .9;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.show-info p {
+  margin: 0;
+  color: var(--muted);
+  font-size: .95rem;
+}
+
+/* --------------------------
+   Episodes
+--------------------------- */
+.nav-back {
+  width: min(1200px, 92vw);
+  margin: 1rem auto 0.5rem;
+}
+.nav-back a {
+  display: inline-block;
+  padding: .5rem .75rem;
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--primary) 8%, transparent);
+  border: 1px solid color-mix(in oklab, var(--primary) 22%, transparent);
+}
+.nav-back a:hover { text-decoration: none; background: color-mix(in oklab, var(--primary) 12%, transparent); }
 
 .episode-card {
-  background-color: #fff;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  padding: 15px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-  transition: transform 0.2s;
+  background: var(--panel);
+  border: 1px solid color-mix(in oklab, var(--muted) 18%, transparent);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1rem;
+  display: grid;
+  gap: .75rem;
+  transition: transform .12s ease, box-shadow .2s ease, border-color .2s ease;
 }
 
 .episode-card:hover {
-  transform: translateY(-5px);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(0,0,0,.28);
+  border-color: color-mix(in oklab, var(--accent) 28%, transparent);
 }
 
 .episode-card h3 {
-  font-size: 16px;
-  margin-bottom: 10px;
-  color: #333;
+  margin: 0 0 .25rem;
+  font-size: 1rem;
 }
 
-.episode-card img {
+.episode-card a img {
   width: 100%;
-  height: auto;
-  border-radius: 4px;
-  margin-bottom: 10px;
+  aspect-ratio: 2 / 3;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid color-mix(in oklab, var(--muted) 18%, transparent);
 }
 
 .episode-card p {
-  font-size: 14px;
-  color: #555;
-  text-align: justify;
-  line-height: 1.5;
-}
-::placeholder {
-  color: rgba(0, 0, 0, 0.599);
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  font-weight: 500;
-}
-/* search container */
-.searchContainer {
-  display: flex;
-  align-items: center;
-  justify-content:center;
-  gap: 15px;
-  background-color: #febfbf;
-  padding: 10px;
-  border-radius: 10px;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  margin:0 -7px ;
-  animation: curtainDrop 1s ease-out forwards;
-  transition: .3s;
-}
-@media (max-width:768px) {
-  .searchContainer {
-    flex-direction: column;
-  }
+  margin: 0;
+  color: var(--muted);
+  font-size: .95rem;
 }
 
-/* select bar  */
-.searchContainer #selectedepisode {
-  padding: 10px 15px;
-  font-size: 16px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  background-color: #fff;
-  color: #333;
-  background-position: right 10px center;
-  background-size: 10px 5px;
-  cursor: pointer;
-  transition: border-color 0.5s ease;
-}
-
-option {
-  color: rgb(1, 54, 46);
-}
-.searchContainer #selectedepisode:focus {
-  outline: none;
-  border: #7ee4c4 2px solid;
-}
-
-/* Search bar  */
-.searchContainer #search {
-  padding: 15px;
-  width: 250px;
-  height: 40px;
-  border-radius: 5px;
-  border: none;
+/* Empty state */
+.notAvailable {
+  width: min(900px, 92vw);
+  margin: 2rem auto 4rem;
+  background: color-mix(in oklab, var(--danger) 8%, var(--panel));
+  border: 1px solid color-mix(in oklab, var(--danger) 20%, transparent);
+  color: var(--text);
+  border-radius: var(--radius);
+  padding: 1.2rem 1rem;
   text-align: center;
 }
 
-.searchContainer #search:focus{
-  outline: none;
-  border: #7ee4c4 2px solid;
-  background-color: #ffffff;
+/* --------------------------
+   Footer
+--------------------------- */
+footer {
+  width: min(1100px, 92vw);
+  margin: 2rem auto 3rem;
+  color: var(--muted);
+  font-size: .95rem;
 }
-.searchContainer p {
-  font-size: large;
-  border-bottom: 3px solid rgb(218, 123, 123) ;
-  cursor: pointer;
-}
-.searchContainer #manyEpisodes{
-  text-decoration: underline;
+footer a { color: var(--primary); }
+
+/* --------------------------
+   Responsive tweaks
+--------------------------- */
+@media (max-width: 760px) {
+  .show-meta { grid-template-columns: 1fr; }
+  .shows-grid,
+  .episode-grid { grid-template-columns: 1fr; }
+  .toolbar,
+  #searchContainer { gap: .65rem .8rem; }
 }
 
-/* intro animation  */
-.hidden {
-  display: none !important;
+@media (min-width: 1500px) {
+  .shows-grid,
+  .episode-grid { width: min(1400px, 92vw); }
 }
 
-.intro-animation {
-  position: fixed;
-  inset: 0;
-  background: #000;
-  z-index: 9999;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-  color: #00ffe1;
-  font-family: 'Orbitron', sans-serif;
+/* --------------------------
+   Motion preferences
+--------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+  .toolbar { backdrop-filter: none; }
 }
-
-.core {
-  width: 48px;
-  height: 48px;
-  background: url(./favicon.ico) no-repeat;
-  box-shadow: 0 0 18px #00ffe1;
-  z-index: 2;
-  border-radius: 50%;
-}
-
-.particle {
-  width: 8px;
-  height: 8px;
-  background: #00ffe1;
-  position: absolute;
-  opacity: 0.8;
-  z-index: 1;
-  border-radius: 50%;
-  animation: assemble .800s ease-in forwards;
-}
-
-.p1 {
-  top: -100px;
-  left: 20%;
-  animation-delay: 0s;
-}
-
-.p2 {
-  top: 120%;
-  left: 30%;
-  animation-delay: 0.05s;
-}
-
-.p3 {
-  top: 50%;
-  left: -100px;
-  animation-delay: 0.1s;
-}
-
-.p4 {
-  top: 40%;
-  left: 120%;
-  animation-delay: 0.15s;
-}
-
-.p5 {
-  top: -80px;
-  left: 80%;
-  animation-delay: 0.1s;
-}
-
-.p6 {
-  top: 130%;
-  left: 70%;
-  animation-delay: 0.04s;
-}
-
-.p7 {
-  top: 10%;
-  left: -60px;
-  animation-delay: 0.2s;
-}
-
-.p8 {
-  top: 60%;
-  left: 130%;
-  animation-delay: 0.1s;
-}
-
-@keyframes assemble {
-  to {
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    opacity: 1;
-  }
-}
-
-.intro-title {
-  font-size: 1.5rem;
-  letter-spacing: 0.12em;
-  margin-top: 30px;
-  opacity: 0;
-  animation: fadeInTitle .2s ease-in .8s forwards;
-}
-
-@keyframes fadeInTitle {
-  to {
-    opacity: 1;
-  }
-}
-/* no episode was found (not available) */
-#notAvailable {
-  display: none;
-  padding: 2rem;
-  margin-top: 2rem;
-  border: 2px dashed #ccc;
-  border-radius: 8px;
-  background-color: #f9f9f9;
-  text-align: center;
-  font-family: Arial, sans-serif;
-  color: #444;
-  animation: fadeIn 0.8s .2s ease-out forwards;
-  opacity: 0;
-}
-
-.notAvailable h2 {
-  font-size: 1.8rem;
-  color: #ffbfbf;
-  margin-bottom: 0.5rem;
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* test */
-


### PR DESCRIPTION


Self checklist

- [X] I have committed my files one by one, on purpose, and for a reason
- [X] I have titled my PR with COHORT_NAME | FIRST_NAME LAST_NAME | REPO_NAME | WEEK 
- [X] I have tested my changes
- [X] My changes follow the [style guide](https://syllabus.codeyourfuture.io/guides/code-style-guide/)
- [x] My changes meet the [requirements](./README.md) of this task

## Changelist

- Present a shows listing on load (name, image, summary, genres, status, rating, runtime)
- Add free-text show search across name, genres, and summary
- Clicking a show loads its episodes, hides shows view, and adds a “Back to shows” link
- Episodes view preserves episode search + selector and works after switching views
- Implement per-visit fetch cache so each URL is requested at most once
- Remove reliance on episodes.js; data now fetched from TVMaze API
- Add responsive styles for shows/episodes grids and sticky toolbar

